### PR TITLE
build package for arm64 arch

### DIFF
--- a/autolib/docker.sh
+++ b/autolib/docker.sh
@@ -17,18 +17,18 @@ RUN set -x && \
     apt-get install -y curl tar build-essential git pkg-config gdb valgrind gcc-10 libmicrohttpd-dev doxygen graphviz && \
     rm -f /usr/bin/gcc && \
     ln -s /usr/bin/gcc-10 /usr/bin/gcc && \
-    curl -sL https://github.com/Kitware/CMake/releases/download/v3.14.5/cmake-3.14.5-Linux-x86_64.tar.gz | tar xzf - -C /opt && \
-    cp /opt/cmake-3.14.5-Linux-x86_64/bin/* /usr/local/bin/ && \
-    cp -R /opt/cmake-3.14.5-Linux-x86_64/share/cmake-3.14 /usr/local/share/ && \
-    curl -sL https://dl.google.com/go/go1.13.1.linux-amd64.tar.gz 2> /dev/null | tar xzf - -C /usr/local && \
+    curl -sL https://github.com/Kitware/CMake/releases/download/v3.19.8/cmake-3.19.8-Linux-aarch64.tar.gz | tar xzf - -C /opt && \
+    cp /opt/cmake-3.19.8-Linux-aarch64/bin/* /usr/local/bin/ && \
+    cp -R /opt/cmake-3.19.8-Linux-aarch64/share/cmake-3.19 /usr/local/share/ && \
+    curl -sL https://dl.google.com/go/go1.13.1.linux-arm64.tar.gz 2> /dev/null | tar xzf - -C /usr/local && \
     mkdir -p /gopath/{src,bin} && \
     printf 'export GOPATH=/gopath\nexport PATH=$PATH:/usr/local/go/bin:/gopath/bin\n' > /root/.bash_profile && \
     printf '#!/usr/bin/env bash\nsource /root/.bash_profile\nexec /bin/bash $@\n' > /entrypoint && \
     chmod +x /entrypoint && \
-    GOPATH=/gopath /usr/local/go/bin/go get github.com/prometheus/prom2json && \
-    GOPATH=/gopath /usr/local/go/bin/go install github.com/prometheus/prom2json/cmd/prom2json && \
-    GOPATH=/gopath /usr/local/go/bin/go get github.com/git-chglog/git-chglog && \
-    GOPATH=/gopath /usr/local/go/bin/go install github.com/git-chglog/git-chglog/cmd/git-chglog && \
+    GOPATH=/gopath GO111MODULE=on /usr/local/go/bin/go get github.com/prometheus/prom2json@v1.3.0 && \
+    GOPATH=/gopath GO111MODULE=on /usr/local/go/bin/go install github.com/prometheus/prom2json/cmd/prom2json && \
+    GOPATH=/gopath GO111MODULE=on /usr/local/go/bin/go get github.com/git-chglog/git-chglog@0.9.1 && \
+    GOPATH=/gopath GO111MODULE=on /usr/local/go/bin/go install github.com/git-chglog/git-chglog/cmd/git-chglog && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code


### PR DESCRIPTION
The original repo provides packages only for x86 architecture, so made some changes to create packages for arm64 arch.

## How to create packages
pre-requisites: Docker, Make, and Bash as written [here](https://github.com/digitalocean/prometheus-client-c#development).

Steps:
```
$ cd /path/to/repo

# checkout to this branch

$ make package
```
Packages are generated at:
* `prom/libprom-dev-0.1.3-Linux.deb`
* `prom/libprom-dev-0.1.3-Linux.tar.gz`
* `promhttp/libpromhttp-dev-0.1.3-Linux.deb`
* `promhttp/libpromhttp-dev-0.1.3-Linux.tar.gz`